### PR TITLE
Make cells from Property and Individuals Matrix editable

### DIFF
--- a/src/main/java/org/coode/matrix/ui/editor/OWLObjectListEditor.java
+++ b/src/main/java/org/coode/matrix/ui/editor/OWLObjectListEditor.java
@@ -2,6 +2,7 @@ package org.coode.matrix.ui.editor;
 
 import java.awt.Component;
 import java.awt.event.MouseEvent;
+import java.util.AbstractList;
 import java.util.Collections;
 import java.util.EventObject;
 import java.util.Set;
@@ -24,6 +25,8 @@ import org.protege.editor.owl.ui.clsdescriptioneditor.OWLAutoCompleter;
 import org.protege.editor.owl.ui.clsdescriptioneditor.OWLExpressionChecker;
 import org.protege.editor.owl.ui.renderer.OWLRendererPreferences;
 import org.semanticweb.owlapi.model.OWLObject;
+
+import com.google.common.collect.ImmutableSet;
 
 /*
 * Copyright (C) 2007, University of Manchester
@@ -129,9 +132,11 @@ public class OWLObjectListEditor extends AbstractCellEditor implements TableCell
 
 
     public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
-
         if (value instanceof FillerModel){
             originalFillers = ((FillerModel)value).getAssertedFillersFromSupers();
+        }
+        else if (value instanceof AbstractList){
+            originalFillers = ImmutableSet.copyOf(((AbstractList)value).iterator());
         }
         else{
             originalFillers = (Set<OWLObject>) value;


### PR DESCRIPTION
Closes #2 by making the cells (the text ones, the others worked) on Property Matrix and Individuals Matrix editable.

Here is the compiled version (just remove the `.zip` on the end and put it in the `plugins` folder to get it working):
[org.coode.matrix-4.0.1-SNAPSHOT.jar.zip](https://github.com/co-ode-owl-plugins/matrix/files/1628643/org.coode.matrix-4.0.1-SNAPSHOT.jar.zip)

It was tested on Windows using Protege 5.2.0
